### PR TITLE
Create new query type for unistore

### DIFF
--- a/pkg/infinity/client.go
+++ b/pkg/infinity/client.go
@@ -292,71 +292,30 @@ func (client *Client) GetResults(ctx context.Context, query models.Query, reques
 			return out, http.StatusOK, duration, err
 		}
 		return string(bodyBytes), http.StatusOK, 0, nil
-	} else if query.Source == "unistore" {
-		// unistore can either pull an entire file (not desired) or a dataframe series
-		if query.Type != "series" {
-			actualType := query.Type
-			query.URL = fmt.Sprintf("%sapis/file.grafana.app/v0alpha1/namespaces/default/files/%s/data", client.Settings.AllowedHosts[0], query.Dataset)
-			//hack because we always return a json that contains a string of json/csv data
-			query.Type = "json"
-			urlResponseObject, statusCode, duration, err := client.req(ctx, query.URL, nil, client.Settings, query, requestHeaders)
-			if err != nil {
-				return urlResponseObject, statusCode, duration, err
-			}
+	} else if query.Type == "unistore" {
+		query.URL = fmt.Sprintf("%sapis/dataset.grafana.app/v0alpha1/namespaces/default/datasets/%s/data", client.Settings.AllowedHosts[0], query.Dataset)
+		//hack because we always return a json that contains the series
+		query.Type = "json"
 
-			if dataMap, ok := urlResponseObject.(map[string]interface{}); ok {
-				if spec, ok := dataMap["spec"].(map[string]interface{}); ok {
-					if dataArray, ok := spec["data"].([]interface{}); ok {
-						// Assuming the "data" array has at least one element
-						if dataObj, ok := dataArray[0].(map[string]interface{}); ok {
-							if contents, ok := dataObj["Contents"].(string); ok {
-								if actualType == "json" {
-									var jsonData interface{}
-									err := json.Unmarshal([]byte(contents), &jsonData)
-									if err != nil {
-										logger.Error("error un-marshaling blob content", "error", err.Error())
-										err = errorsource.PluginError(err, false)
-										return contents, statusCode, duration, err
-									}
-
-									return jsonData, statusCode, duration, nil
-								}
-
-								return contents, statusCode, duration, nil
-							}
-						}
-					}
-				}
-			}
-
-			logger.Error("error un-marshaling blob content", "error", err.Error())
-			err = errorsource.PluginError(err, false)
-			return urlResponseObject, statusCode, duration, err
-		} else {
-			query.URL = fmt.Sprintf("%sapis/dataset.grafana.app/v0alpha1/namespaces/default/datasets/%s/data", client.Settings.AllowedHosts[0], query.Dataset)
-			//hack because we always return a json that contains the series
-			query.Type = "json"
-
-			urlResponseObject, statusCode, duration, err := client.req(ctx, query.URL, nil, client.Settings, query, requestHeaders)
-			if err != nil {
-				return urlResponseObject, statusCode, duration, err
-			}
-
-			if dataMap, ok := urlResponseObject.(map[string]interface{}); ok {
-				if spec, ok := dataMap["spec"].(map[string]interface{}); ok {
-					if dataArray, ok := spec["data"].([]interface{}); ok {
-						// Assuming the "data" array has at least one element
-						if dataframe, ok := dataArray[0].(map[string]interface{}); ok {
-							return dataframe, statusCode, duration, nil
-						}
-					}
-				}
-			}
-
-			logger.Error("error un-marshaling blob content", "error", err.Error())
-			err = errorsource.PluginError(err, false)
+		urlResponseObject, statusCode, duration, err := client.req(ctx, query.URL, nil, client.Settings, query, requestHeaders)
+		if err != nil {
 			return urlResponseObject, statusCode, duration, err
 		}
+
+		if dataMap, ok := urlResponseObject.(map[string]interface{}); ok {
+			if spec, ok := dataMap["spec"].(map[string]interface{}); ok {
+				if dataArray, ok := spec["data"].([]interface{}); ok {
+					// Assuming the "data" array has at least one element
+					if dataframe, ok := dataArray[0].(map[string]interface{}); ok {
+						return dataframe, statusCode, duration, nil
+					}
+				}
+			}
+		}
+
+		logger.Error("error un-marshaling blob content", "error", err.Error())
+		err = errorsource.PluginError(err, false)
+		return urlResponseObject, statusCode, duration, err
 	}
 	switch strings.ToUpper(query.URLOptions.Method) {
 	case http.MethodPost:

--- a/src/app/InfinityProvider.ts
+++ b/src/app/InfinityProvider.ts
@@ -37,6 +37,8 @@ export class InfinityProvider {
       case 'csv':
       case 'tsv':
         return new CSVParser(res, query).getResults();
+      case 'unistore':
+        return res;
       default:
         return undefined;
     }

--- a/src/app/queryUtils.ts
+++ b/src/app/queryUtils.ts
@@ -20,8 +20,6 @@ export const IsValidInfinityQuery = (query: InfinityQuery): boolean => {
       return query.referenceName !== undefined && query.referenceName !== '';
     } else if (query.source === 'azure-blob') {
       return query.azBlobName === '' || query.azContainerName === '';
-    } else if (query.source === 'unistore') {
-      return query.dataset === '';
     } else {
       return query.data !== undefined && query.data !== '';
     }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -302,20 +302,12 @@ export const toTimeSeriesMany = (data: DataFrame[]): DataFrame[] => {
 };
 
 export const fetchDatasets = async (type: string): Promise<string[]> => {
-  let url = '/apis/file.grafana.app/v0alpha1/files';
-  if (type === 'series') {
-    url = '/apis/dataset.grafana.app/v0alpha1/datasets';
-  }
+  const url = '/apis/dataset.grafana.app/v0alpha1/datasets';
   const datasets = await getBackendSrv().get(url);
 
   if (!('items' in datasets)) {
     return [];
   }
 
-  if (type === 'series') {
-    return datasets.items.map((item: any) => item.metadata?.name);
-  }
-
-  //hack in filter - unistore returns an array of objects, we know the first object is the dataset
-  return datasets.items.filter((item: any) => item.spec?.info[0]?.type === type).map((item: any) => item.metadata?.name);
+  return datasets.items.map((item: any) => item.metadata?.name);
 };

--- a/src/components/SourceSelector.tsx
+++ b/src/components/SourceSelector.tsx
@@ -6,7 +6,7 @@ import type { InfinityQuery, InfinityQuerySources } from './../types';
 
 export const SourceSelector = (props: { query: InfinityQuery; onChange: (e: InfinityQuery) => void; onRunQuery: () => void }) => {
   const { query, onChange, onRunQuery } = props;
-  if (query.type === 'global' || query.type === 'google-sheets' || query.type === 'transformations') {
+  if (query.type === 'global' || query.type === 'google-sheets' || query.type === 'transformations' || query.type === 'unistore') {
     return <></>;
   }
   const supportedSources = INFINITY_SOURCES.filter((source) => source.supported_types.includes(query.type));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const SCRAP_QUERY_TYPES: Array<SelectableValue<InfinityQueryType>> = [
   { label: 'Series', value: 'series' },
   { label: 'Global Query', value: 'global' },
   { label: 'Transformations', value: 'transformations' },
+  { label: 'Unified Storage', value: 'unistore' },
 ];
 export const INFINITY_RESULT_FORMATS: Array<SelectableValue<InfinityQueryFormat>> = [
   { label: 'Data Frame', value: 'dataframe' },
@@ -42,7 +43,6 @@ export const INFINITY_SOURCES: ScrapQuerySources[] = [
   { label: 'Inline', value: 'inline', supported_types: ['csv', 'tsv', 'json', 'xml', 'uql', 'groq'] },
   { label: 'Reference', value: 'reference', supported_types: ['csv', 'tsv', 'json', 'xml', 'uql', 'groq'] },
   { label: 'Azure Blob', value: 'azure-blob', supported_types: ['csv', 'tsv', 'json', 'xml', 'uql', 'groq'] },
-  { label: 'Unified Storage', value: 'unistore', supported_types: ['csv', 'json', 'xml', 'series'] },
   { label: 'Random Walk', value: 'random-walk', supported_types: ['series'] },
   { label: 'Expression', value: 'expression', supported_types: ['series'] },
 ];

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -252,10 +252,10 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
           applyGroq(t.groq, data, t.format, t.refId).then(resolve).catch(reject);
           break;
         case 'series':
-          if (t.source === 'unistore') {
-            resolve(data);
-          }
           new SeriesProvider(interpolateQuery(t, scopedVars)).query(new Date(range?.from?.toDate()).getTime(), new Date(range?.to?.toDate()).getTime()).then(resolve).catch(reject);
+          break;
+        case 'unistore':
+          new InfinityProvider(t, this).formatResults(data).then(resolve).catch(reject);
           break;
         case 'global':
           reject('Query not found');

--- a/src/editors/query/infinityQuery.tsx
+++ b/src/editors/query/infinityQuery.tsx
@@ -73,11 +73,10 @@ export const InfinityQueryEditor = (props: InfinityEditorProps) => {
           onShowHelp={() => setShowHelp(!showHelp)}
           datasource={datasource}
         />
-        {query.type === 'series' && query.source !== 'unistore' && <SeriesEditor {...{ query, onChange }} />}
+        {query.type === 'series' && <SeriesEditor {...{ query, onChange }} />}
         {isDataQuery(query) && query.source !== 'inline' && showUrlOptions && <URLEditor {...{ mode, query, onChange, onRunQuery }} />}
         {isDataQuery(query) && query.source === 'azure-blob' && <AzureBlobEditor query={query} onChange={onChange} />}
-        {isDataQuery(query) && query.source === 'unistore' && <UnistoreEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />}
-        {query.type === 'series' && query.source === 'unistore' && <UnistoreEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />}
+        {query.type === 'unistore' && <UnistoreEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />}
         {canShowColumnsEditor && <QueryColumnsEditor {...{ mode, query, onChange, onRunQuery }} />}
         {canShowFilterEditor && <TableFilter {...{ query, onChange, onRunQuery }} />}
         {query.type === 'uql' && (

--- a/src/editors/query/query.unistore.tsx
+++ b/src/editors/query/query.unistore.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Select } from '@grafana/ui';
 import { Stack } from '../../components/extended/Stack';
 import { EditorRow } from '../../components/extended/EditorRow';
-import { isDataQuery, fetchDatasets } from './../../app/utils';
+import { fetchDatasets } from './../../app/utils';
 import type { InfinityQuery } from './../../types';
 import { EditorField } from 'components/extended/EditorField';
 
@@ -20,7 +20,7 @@ export const UnistoreEditor = (props: UnistoreEditorProps) => {
     fetchData();
   }, [query.type]);
 
-  if ((isDataQuery(query) || query.type === 'series') && query.source === 'unistore') {
+  if (query.type === 'unistore') {
     return (
       <EditorRow label="Unistore details" collapsible={false} collapsed={true} title={() => ''}>
         <Stack gap={1} direction="row" wrap={true}>

--- a/src/editors/query/query.url.tsx
+++ b/src/editors/query/query.url.tsx
@@ -108,7 +108,7 @@ const Headers = ({ query, onChange }: { query: InfinityQuery; onChange: (value: 
   if (!(isDataQuery(query) || query.type === 'uql' || query.type === 'groq')) {
     return <></>;
   }
-  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob' || query.source === 'unistore') {
+  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob') {
     return <></>;
   }
   const defaultHeader = {
@@ -131,7 +131,7 @@ const QueryParams = ({ query, onChange, onRunQuery }: { query: InfinityQuery; on
   if (!(isDataQuery(query) || query.type === 'uql' || query.type === 'groq')) {
     return <></>;
   }
-  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob' || query.source === 'unistore') {
+  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob') {
     return <></>;
   }
   const defaultParam = {
@@ -154,7 +154,7 @@ const Body = ({ query, onChange, onRunQuery }: { query: InfinityQuery; onChange:
   if (!(isDataQuery(query) || query.type === 'uql' || query.type === 'groq')) {
     return <></>;
   }
-  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob' || query.source === 'unistore') {
+  if (query.source === 'inline' || query.source === 'reference' || query.source === 'azure-blob') {
     return <></>;
   }
   const placeholderGraphQLQuery = `{ query : { }}`;

--- a/src/types/query.types.ts
+++ b/src/types/query.types.ts
@@ -2,8 +2,8 @@ import { FilterOperator } from './../constants';
 import type { DataQuery, SelectableValue } from '@grafana/data';
 
 //#region Query
-export type InfinityQueryType = 'json' | 'csv' | 'tsv' | 'xml' | 'graphql' | 'html' | 'series' | 'global' | 'uql' | 'groq' | 'google-sheets' | 'transformations';
-export type InfinityQuerySources = 'url' | 'inline' | 'azure-blob' | 'reference' | 'random-walk' | 'expression' | 'unistore';
+export type InfinityQueryType = 'json' | 'csv' | 'tsv' | 'xml' | 'graphql' | 'html' | 'series' | 'global' | 'uql' | 'groq' | 'google-sheets' | 'transformations' | 'unistore';
+export type InfinityQuerySources = 'url' | 'inline' | 'azure-blob' | 'reference' | 'random-walk' | 'expression';
 export type InfinityColumnFormat = 'string' | 'number' | 'timestamp' | 'timestamp_epoch' | 'timestamp_epoch_s' | 'boolean';
 export type InfinityQueryFormat = 'table' | 'timeseries' | 'logs' | 'trace' | 'node-graph-nodes' | 'node-graph-edges' | 'dataframe' | 'as-is';
 export type QueryBodyType = 'none' | 'form-data' | 'x-www-form-urlencoded' | 'raw' | 'graphql';
@@ -36,11 +36,6 @@ export type InfinityQueryWithAzureBlobSource<T extends InfinityQueryType> = {
   azBlobName: string;
 } & InfinityQueryWithSource<'azure-blob'> &
   InfinityQueryBase<T>;
-export type InfinityQueryWithUnistoreSource<T extends InfinityQueryType> = {
-  namespace: string;
-  dataset: string;
-} & InfinityQueryWithSource<'unistore'> &
-  InfinityQueryBase<T>;
 export type InfinityQueryWithInlineSource<T extends InfinityQueryType> = {
   data: string;
 } & InfinityQueryWithSource<'inline'> &
@@ -52,7 +47,7 @@ export type InfinityQueryWithDataSource<T extends InfinityQueryType> = {
   columns: InfinityColumn[];
   filters?: InfinityFilter[];
   format: InfinityQueryFormat;
-} & (InfinityQueryWithURLSource<T> | InfinityQueryWithInlineSource<T> | InfinityQueryWithReferenceSource<T> | InfinityQueryWithAzureBlobSource<T> | InfinityQueryWithUnistoreSource<T>) &
+} & (InfinityQueryWithURLSource<T> | InfinityQueryWithInlineSource<T> | InfinityQueryWithReferenceSource<T> | InfinityQueryWithAzureBlobSource<T>) &
   InfinityQueryBase<T>;
 export type InfinityJSONQueryOptions = {
   root_is_not_array?: boolean;
@@ -74,6 +69,10 @@ export type InfinityCSVQueryOptions = {
   columns?: string;
   comment?: string;
 };
+export type InfinityUnistoreQuery = (
+  | { dataset: string }
+) &
+  InfinityQueryWithDataSource<'unistore'>
 export type InfinityCSVQuery = (
   | { parser?: 'simple'; csv_options?: InfinityCSVQueryOptions }
   | { parser: 'uql'; uql: string }
@@ -98,10 +97,9 @@ export type InfinityHTMLQuery = ({ parser?: 'simple' } | ({ parser: 'backend' } 
 export type InfinitySeriesQueryBase<S extends InfinityQuerySources> = { seriesCount: number; alias: string; dataOverrides: DataOverride[] } & InfinityQueryWithSource<S> & InfinityQueryBase<'series'>;
 export type InfinitySeriesQueryRandomWalk = {} & InfinitySeriesQueryBase<'random-walk'>;
 export type InfinitySeriesQueryExpression = { expression?: string } & InfinitySeriesQueryBase<'expression'>;
-export type InfinitySeriesQueryUnistore = { dataset: string } & InfinitySeriesQueryBase<'unistore'>;
-export type InfinitySeriesQuery = InfinitySeriesQueryRandomWalk | InfinitySeriesQueryExpression | InfinitySeriesQueryUnistore;
+export type InfinitySeriesQuery = InfinitySeriesQueryRandomWalk | InfinitySeriesQueryExpression;
 export type InfinityGlobalQuery = { global_query_id: string } & InfinityQueryBase<'global'>;
-export type InfinityDataQuery = InfinityJSONQuery | InfinityCSVQuery | InfinityTSVQuery | InfinityXMLQuery | InfinityGraphQLQuery | InfinityHTMLQuery;
+export type InfinityDataQuery = InfinityJSONQuery | InfinityCSVQuery | InfinityTSVQuery | InfinityXMLQuery | InfinityGraphQLQuery | InfinityHTMLQuery | InfinityUnistoreQuery;
 export type InfinityDestinationQuery = InfinityDataQuery | InfinitySeriesQuery;
 export type InfinityLegacyQuery = InfinityDestinationQuery | InfinityGlobalQuery;
 export type InfinityUQLQuerySource = InfinityQueryWithURLSource<'uql'> | InfinityQueryWithInlineSource<'uql'>;


### PR DESCRIPTION
This PR cleans a bit all the hacks done here to support unified storage. Currently the only dataframes are supported with this:
- there is a new query type called unified storage that has an input for a saved dataset in unistore.
- based on that dataset, the backend will pull the dataframe and return the data

I've removed all the code that allowed returning arbitrary strings from the `files` unistore endpoint. we would ideally not need to actually edit infinity for that, but instead use the URL scenario to pull a resource representing data from unistore through an app plugin, similar to how images/geojsons are served currently.